### PR TITLE
Make XFCE application switcher background opaque

### DIFF
--- a/src/themes/old-ubuntu-human-blue/gtk-3.0/gtk.css
+++ b/src/themes/old-ubuntu-human-blue/gtk-3.0/gtk.css
@@ -50,3 +50,4 @@
 @import url("tables.css");
 @import url("mate.css");
 @import url("user.css");
+@import url("xfwm.css");

--- a/src/themes/old-ubuntu-human-blue/gtk-3.0/xfwm.css
+++ b/src/themes/old-ubuntu-human-blue/gtk-3.0/xfwm.css
@@ -1,0 +1,40 @@
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin {
+	 padding: 12px;
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_fg;
+	 border-radius: 12px;
+	 /* Set the application icon- and preview-size to 64px */
+	 -XfwmTabwinWidget-icon-size: 64px;
+	 -XfwmTabwinWidget-preview-size: 64px;
+}
+
+#xfwm-tabwin button {
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_text;
+	 border: none;
+	 border-radius: 6px;
+	 box-shadow: none;
+}
+
+#xfwm-tabwin button:active,
+#xfwm-tabwin button:checked {
+ 	 background-color: @theme_selected_bg;
+	 color: @theme_selected_fg;
+}
+
+#xfwm-tabwin button:active:hover,
+#xfwm-tabwin button:checked:hover {
+	 background: lighter(@theme_selected_bg);
+}
+
+#xfwm-tabwin button:hover {
+	 background: lighter(@theme_bg);
+}
+
+#xfwm-tabwin .tabwin-app-grid button {
+	 min-width: 96px;
+	 min-height: 96px;
+}

--- a/src/themes/old-ubuntu-human-green/gtk-3.0/gtk.css
+++ b/src/themes/old-ubuntu-human-green/gtk-3.0/gtk.css
@@ -50,3 +50,4 @@
 @import url("tables.css");
 @import url("mate.css");
 @import url("user.css");
+@import url("xfwm.css");

--- a/src/themes/old-ubuntu-human-green/gtk-3.0/xfwm.css
+++ b/src/themes/old-ubuntu-human-green/gtk-3.0/xfwm.css
@@ -1,0 +1,40 @@
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin {
+	 padding: 12px;
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_fg;
+	 border-radius: 12px;
+	 /* Set the application icon- and preview-size to 64px */
+	 -XfwmTabwinWidget-icon-size: 64px;
+	 -XfwmTabwinWidget-preview-size: 64px;
+}
+
+#xfwm-tabwin button {
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_text;
+	 border: none;
+	 border-radius: 6px;
+	 box-shadow: none;
+}
+
+#xfwm-tabwin button:active,
+#xfwm-tabwin button:checked {
+ 	 background-color: @theme_selected_bg;
+	 color: @theme_selected_fg;
+}
+
+#xfwm-tabwin button:active:hover,
+#xfwm-tabwin button:checked:hover {
+	 background: lighter(@theme_selected_bg);
+}
+
+#xfwm-tabwin button:hover {
+	 background: lighter(@theme_bg);
+}
+
+#xfwm-tabwin .tabwin-app-grid button {
+	 min-width: 96px;
+	 min-height: 96px;
+}

--- a/src/themes/old-ubuntu-human-orange/gtk-3.0/gtk.css
+++ b/src/themes/old-ubuntu-human-orange/gtk-3.0/gtk.css
@@ -50,3 +50,4 @@
 @import url("tables.css");
 @import url("mate.css");
 @import url("user.css");
+@import url("xfwm.css");

--- a/src/themes/old-ubuntu-human-orange/gtk-3.0/xfwm.css
+++ b/src/themes/old-ubuntu-human-orange/gtk-3.0/xfwm.css
@@ -1,0 +1,40 @@
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin {
+	 padding: 12px;
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_fg;
+	 border-radius: 12px;
+	 /* Set the application icon- and preview-size to 64px */
+	 -XfwmTabwinWidget-icon-size: 64px;
+	 -XfwmTabwinWidget-preview-size: 64px;
+}
+
+#xfwm-tabwin button {
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_text;
+	 border: none;
+	 border-radius: 6px;
+	 box-shadow: none;
+}
+
+#xfwm-tabwin button:active,
+#xfwm-tabwin button:checked {
+ 	 background-color: @theme_selected_bg;
+	 color: @theme_selected_fg;
+}
+
+#xfwm-tabwin button:active:hover,
+#xfwm-tabwin button:checked:hover {
+	 background: lighter(@theme_selected_bg);
+}
+
+#xfwm-tabwin button:hover {
+	 background: lighter(@theme_bg);
+}
+
+#xfwm-tabwin .tabwin-app-grid button {
+	 min-width: 96px;
+	 min-height: 96px;
+}

--- a/src/themes/old-ubuntu-human/gtk-3.0/gtk.css
+++ b/src/themes/old-ubuntu-human/gtk-3.0/gtk.css
@@ -50,3 +50,4 @@
 @import url("tables.css");
 @import url("mate.css");
 @import url("user.css");
+@import url("xfwm.css");

--- a/src/themes/old-ubuntu-human/gtk-3.0/xfwm.css
+++ b/src/themes/old-ubuntu-human/gtk-3.0/xfwm.css
@@ -1,0 +1,40 @@
+/* Xfwm4's alt-tab dialog, aka "tabwin" */
+#xfwm-tabwin {
+	 padding: 12px;
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_fg;
+	 border-radius: 12px;
+	 /* Set the application icon- and preview-size to 64px */
+	 -XfwmTabwinWidget-icon-size: 64px;
+	 -XfwmTabwinWidget-preview-size: 64px;
+}
+
+#xfwm-tabwin button {
+	 background-image: none;
+	 background-color: @theme_bg;
+	 color: @theme_text;
+	 border: none;
+	 border-radius: 6px;
+	 box-shadow: none;
+}
+
+#xfwm-tabwin button:active,
+#xfwm-tabwin button:checked {
+ 	 background-color: @theme_selected_bg;
+	 color: @theme_selected_fg;
+}
+
+#xfwm-tabwin button:active:hover,
+#xfwm-tabwin button:checked:hover {
+	 background: lighter(@theme_selected_bg);
+}
+
+#xfwm-tabwin button:hover {
+	 background: lighter(@theme_bg);
+}
+
+#xfwm-tabwin .tabwin-app-grid button {
+	 min-width: 96px;
+	 min-height: 96px;
+}


### PR DESCRIPTION
The application switcher in XFCE (the popup that appears when you press
Alt-Tab) has a style which make the background transparent. If you have
a dark background and dark themes in the windows, only the current
selected line is visible as you scroll over it.

This patch adds an opaque background to that window class in particular,
trying to mimic the style as it was in XFCE 4.12 with the Human theme of
Ubuntu 16.04, although I admittedly have not ensured that the colors and
borders are pixel-perfect.